### PR TITLE
fix: change Total PV Production state_class to total_increasing

### DIFF
--- a/deye-esp32-bridge-pace.yaml
+++ b/deye-esp32-bridge-pace.yaml
@@ -2197,7 +2197,7 @@ sensor:
     register_type: holding
     address: 534
     unit_of_measurement: "kWh"
-    state_class: "measurement"
+    state_class: "total_increasing"
     device_class: energy
     accuracy_decimals: 1
     value_type: U_DWORD_R

--- a/deye-esp32-bridge.yaml
+++ b/deye-esp32-bridge.yaml
@@ -889,7 +889,7 @@ sensor:
     register_type: holding
     address: 534
     unit_of_measurement: "kWh"
-    state_class: "measurement"
+    state_class: "total_increasing"
     device_class: energy
     accuracy_decimals: 1
     value_type: U_DWORD_R

--- a/deye-multi-seplosv3.yaml
+++ b/deye-multi-seplosv3.yaml
@@ -898,7 +898,7 @@ sensor:
     register_type: holding
     address: 534
     unit_of_measurement: "kWh"
-    state_class: "measurement"
+    state_class: "total_increasing"
     device_class: energy
     accuracy_decimals: 1
     value_type: U_DWORD_R

--- a/deye-seplosV3.yaml
+++ b/deye-seplosV3.yaml
@@ -241,7 +241,7 @@ sensor:
     register_type: holding
     address: 534
     unit_of_measurement: "kWh"
-    state_class: "measurement"
+    state_class: "total_increasing"
     device_class: energy
     accuracy_decimals: 1
     value_type: U_DWORD_R


### PR DESCRIPTION
This pull request was generated by @kiro-agent :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Fixes #34

The `Total PV Production` sensor (register 534) is a cumulative energy counter that only increases over time. It was incorrectly using `state_class: "measurement"`, which causes a "last reset missing" error in Home Assistant's Energy Dashboard and Statistics.

Changed `state_class` from `"measurement"` to `"total_increasing"` in all four configuration files:

- `deye-esp32-bridge.yaml`
- `deye-esp32-bridge-pace.yaml`
- `deye-multi-seplosv3.yaml`
- `deye-seplosV3.yaml`

## Rationale

Per Home Assistant's sensor documentation, `total_increasing` is the correct state class for sensors that represent a monotonically increasing total (like a cumulative energy production counter in kWh). This allows HA to properly track the sensor in the Energy Dashboard without requiring a `last_reset` attribute.